### PR TITLE
[OpenSearch] Add more provider credential options

### DIFF
--- a/src/Builder/ClientBuilder.php
+++ b/src/Builder/ClientBuilder.php
@@ -28,8 +28,26 @@ class ClientBuilder implements ClientBuilderInterface
         $client = \OpenSearch\ClientBuilder::create();
         $client->setHosts($indexOptions['index']['hosts']);
 
-        if (!empty($indexOptions['index']['credentials']['username']) && $indexOptions['index']['credentials']['password']) {
-            $client->setBasicAuthentication($indexOptions['index']['credentials']['username'], $indexOptions['index']['credentials']['password']);
+        $credentials = $indexOptions['index']['credentials'];
+
+        if (!empty($credentials['username']) && $credentials['password']) {
+            $client->setBasicAuthentication($credentials['username'], $credentials['password']);
+        } else {
+            if (!empty($credentials['sig_v4_region'])) {
+                $client->setSigV4Region($credentials['sig_v4_region']);
+            }
+
+            if (!empty($credentials['sig_v4_service'])) {
+                $client->setSigV4Service($credentials['sig_v4_service']);
+            }
+
+            if ($credentials['sig_v4_credential_provider'] !== null) {
+                $client->setSigV4CredentialProvider($credentials['sig_v4_credential_provider']);
+            }
+        }
+
+        if ($credentials['ssl_verification'] !== null) {
+            $client->setSSLVerification($credentials['ssl_verification']);
         }
 
         return $client->build();

--- a/src/Provider/OpenSearchIndexProvider.php
+++ b/src/Provider/OpenSearchIndexProvider.php
@@ -13,6 +13,7 @@
 
 namespace DsOpenSearchBundle\Provider;
 
+use Aws\Credentials\CredentialsInterface;
 use DsOpenSearchBundle\Builder\ClientBuilderInterface;
 use DsOpenSearchBundle\DsOpenSearchBundle;
 use DsOpenSearchBundle\Service\IndexPersistenceService;
@@ -48,10 +49,23 @@ class OpenSearchIndexProvider implements IndexProviderInterface, PreConfiguredIn
                         $spoolResolver->setDefaults([
                             'username' => null,
                             'password' => null,
+                            'ssl_verification' => null,
+                            'sig_v4_region' => null,
+                            'sig_v4_credential_provider' => null,
                         ]);
 
                         $spoolResolver->setAllowedTypes('username', ['string', 'null']);
                         $spoolResolver->setAllowedTypes('password', ['string', 'null']);
+                        $spoolResolver->setAllowedTypes('ssl_verification', ['bool', 'string', 'null']);
+                        $spoolResolver->setAllowedTypes('sig_v4_region', ['string', 'null']);
+                        $spoolResolver->setAllowedTypes('sig_v4_service', ['string', 'null']);
+                        $spoolResolver->setAllowedTypes('sig_v4_credential_provider', [
+                            'array',
+                            'bool',
+                            'callable',
+                            CredentialsInterface::class,
+                            'null'
+                        ]);
                     },
                 ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

This PR adds the connection options, which are mentioned in the docs [here](https://opensearch.org/docs/latest/clients/php/). There are a few more options, when it comes to build a OpenSearch client instance. It probably would make sense to use the [`fromConfig`](https://github.com/opensearch-project/opensearch-php/blob/main/src/OpenSearch/ClientBuilder.php#L224) method to cover all of them, but that would probably introduce some BC breaks as e.g. username and password credentials have to be configured as an array instead of separate values, etc.